### PR TITLE
Enable mark jumping via letter key

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A modern Neovim plugin for enhanced mark management with a beautiful popup inter
 - 🎨 **Beautiful popup interface** - Clean, modern UI for browsing marks
 - 🎯 **Mark types support** - Buffer marks (a-z) and global marks (A-Z)
 - 📝 **Line preview** - See the actual content at each mark
-- ⚡ **Fast navigation** - Jump to marks with Enter or click
+- ⚡ **Fast navigation** - Jump to marks with Enter, click, or by pressing the mark letter
 - 🗑️ **Easy deletion** - Delete marks with 'd' key
 - 👻 **Virtual text** - See mark indicators directly in your code
 - 🎛️ **Configurable** - Customize appearance and keybindings
@@ -66,6 +66,7 @@ Plug 'developedbyed/marko.nvim'
 
 3. **Navigate in the popup**:
    - `Enter` - Jump to mark
+   - Press mark letter - Jump to that mark
    - `d` - Delete mark
    - `q` or `Esc` - Close popup
 

--- a/lua/marko/popup.lua
+++ b/lua/marko/popup.lua
@@ -455,6 +455,28 @@ function M.setup_keymaps()
     vim.cmd("normal! k")
     constrain_cursor()
   end, { buffer = popup_buf, silent = true })
+
+  -- Jump to a mark directly when its letter is pressed
+  local marks_data = vim.b[popup_buf].marks_data or {}
+  local reserved = {
+    [config.keymaps.delete] = true,
+    [config.keymaps.goto] = true,
+    [config.keymaps.close] = true,
+  }
+  if config.default_keymap then
+    reserved[config.default_keymap] = true
+  end
+
+  for _, mark in ipairs(marks_data) do
+    local letter = mark.mark
+    if not reserved[letter] then
+      local mark_data = mark
+      vim.keymap.set("n", letter, function()
+        M.close_popup()
+        marks_module.goto_mark(mark_data)
+      end, { buffer = popup_buf, silent = true })
+    end
+  end
 end
 
 -- Close the popup


### PR DESCRIPTION
## Summary
- add direct mark letter navigation in popup
- document how to jump to marks by pressing the letter

## Testing
- `luacheck lua` *(fails: 158 warnings / 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687824efabc883289fa7f9ea72864490